### PR TITLE
Improve DM permission grant/revoke embeds

### DIFF
--- a/accord.py
+++ b/accord.py
@@ -16,6 +16,7 @@ GUILD_ID = os.getenv("DISCORD_TOKEN")
 
 BYPASS_ROLE_IDS = set()
 CONSENT_FILE = "consent_data.json"
+CONSENT_MESSAGE_FILE = "consent_messages.json"
 
 DEBUG = True  # Set to False when going global
 REQUEST_CHANNELS = {}  # {guild_id: channel_id}
@@ -29,6 +30,7 @@ intents.members = True
 
 # Interaction Consent State
 INTERACTION_PAIRS = {}        # {channel_id: set(("userA","userB"))}
+CONSENT_MESSAGES = {}         # {guild_id: {"min:max": {channel_id, message_id, requester_id, target_id}}}
 
 AUDIT_LOG_CHANNEL_ID = None
 AUDIT_FILE = "dm_audit_log.json"
@@ -62,6 +64,7 @@ bot = Bot()
 async def on_ready():
     print(f"Logged in as {bot.user} (ID: {bot.user.id})")
     load_consent()
+    load_consent_messages()
     load_request_channels()
     print("------")
 
@@ -155,6 +158,27 @@ def load_consent():
         INTERACTION_PAIRS = {}
 
 
+def _pair_key(user_a_id: int, user_b_id: int) -> str:
+    low, high = sorted((user_a_id, user_b_id))
+    return f"{low}:{high}"
+
+
+def load_consent_messages():
+    global CONSENT_MESSAGES
+    try:
+        with open(CONSENT_MESSAGE_FILE, "r") as f:
+            raw = json.load(f)
+
+        CONSENT_MESSAGES = {int(guild_id): messages for guild_id, messages in raw.items()}
+    except FileNotFoundError:
+        CONSENT_MESSAGES = {}
+
+
+def save_consent_messages():
+    with open(CONSENT_MESSAGE_FILE, "w") as f:
+        json.dump(CONSENT_MESSAGES, f, indent=4)
+
+
 def save_consent():
     output = {}
 
@@ -171,6 +195,50 @@ def save_consent():
 
     with open(CONSENT_FILE, "w") as f:
         json.dump(output, f, indent=4)
+
+
+async def update_consent_embed_revoked(
+    guild: discord.Guild,
+    user_one: discord.Member,
+    user_two: discord.Member,
+    revoked_by: discord.Member
+):
+    guild_messages = CONSENT_MESSAGES.get(guild.id)
+    if not guild_messages:
+        return
+
+    key = _pair_key(user_one.id, user_two.id)
+    message_ref = guild_messages.get(key)
+    if not message_ref:
+        return
+
+    channel = guild.get_channel(message_ref["channel_id"])
+    if not channel:
+        return
+
+    try:
+        message = await channel.fetch_message(message_ref["message_id"])
+    except (discord.NotFound, discord.Forbidden, AttributeError):
+        return
+
+    revoked_embed = discord.Embed(
+        title="🚫 DM Permission Revoked",
+        description=(
+            f"DM permission between {user_one.mention} and {user_two.mention} has been revoked.\n\n"
+            f"Revoked by: **{revoked_by.display_name}**"
+        ),
+        color=discord.Color.red()
+    )
+
+    try:
+        await message.edit(embed=revoked_embed, view=None)
+    except (discord.NotFound, discord.Forbidden):
+        return
+
+    del guild_messages[key]
+    if not guild_messages:
+        del CONSENT_MESSAGES[guild.id]
+    save_consent_messages()
 
 
 class AskConsentView(discord.ui.View):
@@ -221,15 +289,34 @@ class AskConsentView(discord.ui.View):
         for child in self.children:
             child.disabled = True
 
+        requester = interaction.guild.get_member(self.requester_id)
+        requester_mention = requester.mention if requester else f"<@{self.requester_id}>"
+        target_mention = interaction.user.mention
+
         success_embed = discord.Embed(
             title="✅ DM Permission Granted",
-            description="Both users may now DM each other.",
+            description=(
+                f"Consent confirmed by both users.\n\n"
+                f"• Requester: {requester_mention}\n"
+                f"• Target: {target_mention}\n\n"
+                "Both users may now DM each other."
+            ),
             color=discord.Color.green()
         )
 
+        if self.message and self.message.channel:
+            guild_messages = CONSENT_MESSAGES.setdefault(interaction.guild.id, {})
+            guild_messages[_pair_key(self.requester_id, self.target_id)] = {
+                "channel_id": self.message.channel.id,
+                "message_id": self.message.id,
+                "requester_id": self.requester_id,
+                "target_id": self.target_id,
+            }
+            save_consent_messages()
+
         await log_audit_event(
             interaction.guild,
-            f"DM request accepted: {interaction.user.display_name} ↔ requester"
+            f"DM request accepted: {interaction.user.display_name} ↔ {requester.display_name if requester else self.requester_id}"
         )
 
         await interaction.response.edit_message(
@@ -568,6 +655,7 @@ async def dm_revoke(interaction: discord.Interaction, user: discord.Member):
 
     if removed:
         save_consent()
+        await update_consent_embed_revoked(interaction.guild, interaction.user, user, interaction.user)
         await interaction.response.send_message(
             f"DM consent revoked with {user.mention}."
         )

--- a/accord.py
+++ b/accord.py
@@ -202,24 +202,36 @@ async def update_consent_embed_revoked(
     user_one: discord.Member,
     user_two: discord.Member,
     revoked_by: discord.Member
-):
+) -> bool:
     guild_messages = CONSENT_MESSAGES.get(guild.id)
     if not guild_messages:
-        return
+        return False
 
     key = _pair_key(user_one.id, user_two.id)
     message_ref = guild_messages.get(key)
     if not message_ref:
-        return
+        return False
 
-    channel = guild.get_channel(message_ref["channel_id"])
+    channel_id = message_ref["channel_id"]
+    bot_get_channel = getattr(bot, "get_channel", None)
+    channel = guild.get_channel(channel_id)
+    if not channel and callable(bot_get_channel):
+        channel = bot_get_channel(channel_id)
+
     if not channel:
-        return
+        bot_fetch_channel = getattr(bot, "fetch_channel", None)
+        if callable(bot_fetch_channel):
+            try:
+                channel = await bot_fetch_channel(channel_id)
+            except (discord.NotFound, discord.Forbidden, AttributeError):
+                return False
+        else:
+            return False
 
     try:
         message = await channel.fetch_message(message_ref["message_id"])
     except (discord.NotFound, discord.Forbidden, AttributeError):
-        return
+        return False
 
     revoked_embed = discord.Embed(
         title="🚫 DM Permission Revoked",
@@ -231,14 +243,19 @@ async def update_consent_embed_revoked(
     )
 
     try:
-        await message.edit(embed=revoked_embed, view=None)
+        await message.edit(
+            content=f"🔁 Consent update: {user_one.mention} ↔ {user_two.mention}",
+            embed=revoked_embed,
+            view=None
+        )
     except (discord.NotFound, discord.Forbidden):
-        return
+        return False
 
     del guild_messages[key]
     if not guild_messages:
         del CONSENT_MESSAGES[guild.id]
     save_consent_messages()
+    return True
 
 
 class AskConsentView(discord.ui.View):
@@ -320,6 +337,7 @@ class AskConsentView(discord.ui.View):
         )
 
         await interaction.response.edit_message(
+            content=f"✅ Consent confirmed: {requester_mention} ↔ {target_mention}",
             embed=success_embed,
             view=self
         )
@@ -655,9 +673,10 @@ async def dm_revoke(interaction: discord.Interaction, user: discord.Member):
 
     if removed:
         save_consent()
-        await update_consent_embed_revoked(interaction.guild, interaction.user, user, interaction.user)
+        embed_updated = await update_consent_embed_revoked(interaction.guild, interaction.user, user, interaction.user)
+        suffix = " Updated the original request message." if embed_updated else " Could not update the original request message."
         await interaction.response.send_message(
-            f"DM consent revoked with {user.mention}."
+            f"DM consent revoked with {user.mention}.{suffix}"
         )
     else:
         await interaction.response.send_message(

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -258,3 +258,52 @@ def test_dm_set_audit_channel_requires_manage_guild_permission(accord_module):
     kwargs = interaction.response.send_message.await_args.kwargs
     assert get_sent_text(interaction.response.send_message) == "You do not have permission to configure audit logging."
     assert kwargs["ephemeral"] is True
+
+
+def test_accept_embed_lists_both_consented_users(accord_module, monkeypatch):
+    monkeypatch.setattr(accord_module, "save_consent", lambda: None)
+    monkeypatch.setattr(accord_module, "save_consent_messages", lambda: None)
+
+    requester = make_member(member_id=10, display_name="Requester")
+    target = make_member(member_id=20, display_name="Target")
+    guild = make_guild(guild_id=333, members={10: requester, 20: target})
+    interaction = make_interaction(guild, target)
+
+    view = accord_module.AskConsentView(requester_id=10, target_id=20)
+    view.message = SimpleNamespace(id=999, channel=SimpleNamespace(id=321))
+
+    run(view.accept(interaction, None))
+
+    embed = interaction.response.edit_message.await_args.kwargs["embed"]
+    assert "Requester: <@10>" in embed.description
+    assert "Target: <@20>" in embed.description
+
+
+def test_dm_revoke_updates_existing_grant_embed(accord_module, monkeypatch):
+    monkeypatch.setattr(accord_module, "save_consent", lambda: None)
+
+    requester = make_member(member_id=10, display_name="Requester")
+    target = make_member(member_id=20, display_name="Target")
+
+    message = SimpleNamespace(edit=AsyncMock())
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
+    guild = make_guild(guild_id=555, channels={77: channel})
+    interaction = make_interaction(guild, requester)
+
+    accord_module.INTERACTION_PAIRS = {555: {(10, 20), (20, 10)}}
+    accord_module.CONSENT_MESSAGES = {
+        555: {
+            "10:20": {
+                "channel_id": 77,
+                "message_id": 88,
+                "requester_id": 10,
+                "target_id": 20,
+            }
+        }
+    }
+
+    run(accord_module.dm_revoke(interaction, target))
+
+    message.edit.assert_awaited_once()
+    revoked_embed = message.edit.await_args.kwargs["embed"]
+    assert revoked_embed.title == "🚫 DM Permission Revoked"


### PR DESCRIPTION
### Motivation

- Make explicit which two users consented when a DM permission is granted so the grant message is clear and auditable.
- Allow revocation to update the original grant message so recipients can see that a previously granted consent was later revoked.

### Description

- Added persistent tracking for grant message metadata via `CONSENT_MESSAGE_FILE` and the `CONSENT_MESSAGES` structure, plus `_pair_key`, `load_consent_messages`, and `save_consent_messages` helpers in `accord.py`.
- Updated the grant flow in `AskConsentView.accept` to include both requester and target mentions in the "✅ DM Permission Granted" embed and to store the grant message reference when available.
- Implemented `update_consent_embed_revoked` to locate and edit the original grant message to a "🚫 DM Permission Revoked" embed, remove the stored metadata, and handle missing/permission errors gracefully.
- Wired `dm_revoke` to call `update_consent_embed_revoked` when a consent pair is removed, and added tests in `tests/test_slash_commands.py` for the grant embed content and revoke embed update.

### Testing

- Ran `pytest -q` and all tests passed (output: 100% green).
- Added unit tests `test_accept_embed_lists_both_consented_users` and `test_dm_revoke_updates_existing_grant_embed` which both passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d7042704832b8001214a6abedc58)